### PR TITLE
#7 Keep device keyboard opened after sending message

### DIFF
--- a/src/ChatWindow/Room.vue
+++ b/src/ChatWindow/Room.vue
@@ -421,7 +421,10 @@ export default {
 
     if (detectMobile()) {
       this.$refs['roomTextarea'].addEventListener('blur', e => {
-        this.preventMobileKeyboadFromClosing()
+        setTimeout(() => this.keepMobileKeyboardOpen = false, 0)
+      })
+      this.$refs['roomTextarea'].addEventListener('click', e => {
+        this.keepMobileKeyboardOpen = true
       })
     }
 
@@ -635,6 +638,7 @@ export default {
 			this.imageDimensions = null
 			this.imageFile = null
 			this.emojiOpened = false
+      this.preventMobileKeyboardFromClosing()
 			setTimeout(() => this.focusTextarea(disableMobileFocus), 0)
 		},
 		resetImageFile() {
@@ -657,9 +661,8 @@ export default {
 		isMessageEmpty() {
 			return !this.file && !this.message.trim()
 		},
-    preventMobileKeyboadFromClosing() {
+    preventMobileKeyboardFromClosing() {
       if (this.keepMobileKeyboardOpen) {
-        this.keepMobileKeyboardOpen = false
         this.$refs['roomTextarea'].focus()
       }
     },

--- a/src/ChatWindow/Room.vue
+++ b/src/ChatWindow/Room.vue
@@ -400,7 +400,8 @@ export default {
 			newMessages: [],
 			recorderStream: {},
 			recorder: {},
-			recordedChunks: []
+			recordedChunks: [],
+      keepMobileKeyboardOpen: false,
 		}
 	},
 
@@ -417,6 +418,12 @@ export default {
 				}
 			}
 		})
+
+    if (detectMobile()) {
+      this.$refs['roomTextarea'].addEventListener('blur', e => {
+        this.preventMobileKeyboadFromClosing()
+      })
+    }
 
 		this.$refs.scrollContainer.addEventListener('scroll', e => {
 			this.hideOptions = true
@@ -650,6 +657,12 @@ export default {
 		isMessageEmpty() {
 			return !this.file && !this.message.trim()
 		},
+    preventMobileKeyboadFromClosing() {
+      if (this.keepMobileKeyboardOpen) {
+        this.keepMobileKeyboardOpen = false
+        this.$refs['roomTextarea'].focus()
+      }
+    },
 		sendMessage() {
 			if (!this.file && !this.message.trim()) return
 
@@ -716,6 +729,7 @@ export default {
 			element.scrollTo({ top: element.scrollHeight, behavior: 'smooth' })
 		},
 		onChangeInput() {
+      this.keepMobileKeyboardOpen = true
 			this.resizeTextarea()
 			this.$emit('typing-message', this.message)
 		},


### PR DESCRIPTION
#7 Keep device keyboard opened after sending message

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:


When someone typed on the mobile device, we can know that the keyboard of the mobile phone has been opened. And we need to keep the keyboard open.

```
onChangeInput() {  
    this.keepMobileKeyboardOpen = true  
    ...  
}  
```

After message is sent, the keyboard will close because the textarea loses focus. We need to keep focusing the textarea to prevent the keyboard from closing.

```
this.$refs['roomTextarea'].addEventListener('blur', e => {
    if (this.keepMobileKeyboardOpen) {
        this.keepMobileKeyboardOpen = false
        this.$refs['roomTextarea'].focus()
    }
})
```

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing

**Other information:**

Tested on my android 8 device, but still need someone to help test on ios or other devices.
