### PR TITLE
(fix) scroll event not listened in Electron

### DIFF
--- a/src/ChatWindow/Room/Room.vue
+++ b/src/ChatWindow/Room/Room.vue
@@ -32,7 +32,7 @@
 			</template>
 		</room-header>
 
-		<div ref="scrollContainer" class="vac-container-scroll">
+		<div ref="scrollContainer" class="vac-container-scroll" @scroll="containerScroll">
 			<loader :show="loadingMessages" />
 			<div class="vac-messages-container">
 				<div :class="{ 'vac-messages-hidden': loadingMessages }">
@@ -496,17 +496,6 @@ export default {
 			this.resetUsersTag()
 			if (isMobile) setTimeout(() => (this.keepKeyboardOpen = false), 0)
 		})
-
-		this.$refs.scrollContainer.addEventListener('scroll', e => {
-			this.hideOptions = true
-			setTimeout(() => {
-				if (!e.target) return
-
-				const bottomScroll = this.getBottomScroll(e.target)
-				if (bottomScroll < 60) this.scrollMessagesCount = 0
-				this.scrollIcon = bottomScroll > 500 || this.scrollMessagesCount
-			}, 200)
-		})
 	},
 
 	methods: {
@@ -803,6 +792,16 @@ export default {
 		},
 		textareaActionHandler() {
 			this.$emit('textarea-action-handler', this.message)
+		},
+		containerScroll(e) {
+			this.hideOptions = true
+			setTimeout(() => {
+				if (!e.target) return
+
+				const bottomScroll = this.getBottomScroll(e.target)
+				if (bottomScroll < 60) this.scrollMessagesCount = 0
+				this.scrollIcon = bottomScroll > 500 || this.scrollMessagesCount
+			}, 200)
 		}
 	}
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I found it's unable to listen 'scroll' event using `this.$refs[...].addEventListener(...)` in `mounted()` when I am using Electron 11.2.3 and Vue 2.6.12. 

So I moved the function to a function called `containerScroll(e)` and use `@scroll` to listen the scroll event, it finally works