### PR TITLE
(fix) slot binding name

### DIFF
--- a/src/lib/RoomsList/RoomContent/RoomContent.vue
+++ b/src/lib/RoomsList/RoomContent/RoomContent.vue
@@ -28,7 +28,7 @@
 					}"
 				>
 					<span v-if="isMessageCheckmarkVisible">
-						<slot name="checkmark-icon" v-bind="room.lastMessage">
+						<slot name="checkmark-icon" v-bind="{message: room.lastMessage}">
 							<svg-icon
 								:name="
 									room.lastMessage.distributed


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Slot "checkmark-icon" had different bindings 

- Message.vue line 135 `<slot name="checkmark-icon" v-bind="{ message }">`
- RoomContent line 31 `<slot name="checkmark-icon" v-bind="room.lastMessage">`

So I could not similarly access message object. I fixed it by giving the same name to message `v-bind="{message: room.lastMessage}"` in RoomContent. 
I have tested this change and now it works as expected.
