### PR TITLE
add rel attribute to link-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ fetchMessages({ room, options }) {
 | `show-footer`(13)                   | Boolean          | -        | `true`                                  |
 | `text-messages`(14)                 | Object           | -        | `null`                                  |
 | `text-formatting`(15)               | Boolean          | -        | `true`                                  |
-| `link-options`(16)                  | Object           | -        | `{ disabled: false, target: '_blank' }` |
+| `link-options`(16)                  | Object           | -        | `{ disabled: false, target: '_blank', rel: null }` |
 | `room-info-enabled` (17)            | Boolean          | -        | `false`                                 |
 | `textarea-action-enabled`(18)       | Boolean          | -        | `false`                                 |
 | `responsive-breakpoint`(19)         | Number           | -        | `900`                                   |
@@ -397,7 +397,7 @@ multiline code
 **(16)** `link-options` can be used to disable url links in messages, or change urls target. Ex:
 
 ```javascript
-:link-options="{ disabled: true, target: '_self' }"
+:link-options="{ disabled: true, target: '_self', rel: null }"
 ```
 
 **(17)** `room-info-enabled` can be used to trigger an event after clicking the room header component.<br>

--- a/src/components/FormatMessage/FormatMessage.vue
+++ b/src/components/FormatMessage/FormatMessage.vue
@@ -23,6 +23,7 @@
 					}"
 					:href="message.href"
 					:target="message.href ? linkOptions.target : null"
+          :rel="message.href ? linkOptions.rel : null"
 					@click="openTag(message)"
 				>
 					<slot name="deleted-icon" v-bind="{ deleted }">

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -134,7 +134,7 @@ export default {
 		textFormatting: { type: Boolean, default: true },
 		linkOptions: {
 			type: Object,
-			default: () => ({ disabled: false, target: '_blank' })
+			default: () => ({ disabled: false, target: '_blank', rel: null })
 		},
 		roomInfoEnabled: { type: Boolean, default: false },
 		textareaActionEnabled: { type: Boolean, default: false },


### PR DESCRIPTION
Duo to the potential security issue when using `target="_blank"` on links, we need to be able to set rel attribute on html a tag.
About the security issue: [Links to cross-origin destinations are unsafe](https://web.dev/external-anchors-use-rel-noopener/)

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
