### PR TITLE
(fix) backward and forward rotation for RoomsList toggle-button icon

### DIFF
--- a/src/lib/Room/RoomHeader/RoomHeader.scss
+++ b/src/lib/Room/RoomHeader/RoomHeader.scss
@@ -28,6 +28,9 @@
 	}
 
 	.vac-rotate-icon {
+		&-init {
+			transform: rotate(360deg);
+		}
 		transform: rotate(180deg) !important;
 	}
 

--- a/src/lib/Room/RoomHeader/RoomHeader.vue
+++ b/src/lib/Room/RoomHeader/RoomHeader.vue
@@ -33,7 +33,7 @@
 					<div
 						v-if="!singleRoom"
 						class="vac-svg-button vac-toggle-button"
-						:class="{ 'vac-rotate-icon': !showRoomsList && !isMobile }"
+						:class="{ 'vac-rotate-icon-init': !isMobile, 'vac-rotate-icon': !showRoomsList && !isMobile }"
 						@click="$emit('toggle-rooms-list')"
 					>
 						<slot name="toggle-icon">


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

Without this fix the toggle-button icon is rotating counter-clockwise on RoomsList closing and also counter-clockwise on opening.

With this fix the toggle-button icon is rotating counter-clockwise on RoomsList closing and then *clockwise* on opening.