### PR TITLE
fix #302 Set rooms order as optional property

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -162,12 +162,12 @@ export interface Slots {
 export interface Props {
 	'current-user-id': StringNumber
 	rooms: Rooms
-	'rooms-order': 'desc' | 'asc'
 	messages: Messages
-	height?: string
-	theme?: 'light' | 'dark'
-	styles?: Record<string, Record<string, string>>
-	'loading-rooms'?: boolean
+  height?: string
+  theme?: 'light' | 'dark'
+  styles?: Record<string, Record<string, string>>
+  'rooms-order'?: 'desc' | 'asc'
+  'loading-rooms'?: boolean
 	'rooms-loaded'?: boolean
 	'room-id'?: StringNumber
 	'load-first-room'?: boolean


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
Fixes issue #302 

I also changed properties order, moving `"rooms-order"`  property to other properties with quotation marks

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
