### PR TITLE
(feature) add method-callback to signal 'message-action-handler'

### DIFF
--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -514,7 +514,7 @@ export default {
 					this.messageSelectionEnabled = true
 					return
 				default:
-					return this.$emit('message-action-handler', { action, message })
+					return this.$emit('message-action-handler', { action, message, methodCallback: this.messageActionHandler })
 			}
 		},
 		messageSelectionActionHandler(action) {


### PR DESCRIPTION
This enables custom action handlers to make a callback to the default action-handler.

```js
<template>
    <chat-window
        @message-action-handler="messageActionHandler"
    >
</template>

<script>
export default {
  name: 'ChatContainer',
  components: {
    ChatWindow
  },
  data() {
    return {
      messageActions: [
        {
          name: 'replyMessageCustom',
          title: 'Reply'
        }
      ],
  },
  methods: {
    messageActionHandler({ action, message, roomId, methodCallback }) {
      if (action.name === 'replyMessageCustom') {
        /*
         * Do something here.
         */
        methodCallback({ action: {name: 'replyMessage'}, message })
      }
    }
  }
}
</script>
```

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing (The one and only test 'RoomsList.spec.js' passed.)

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Additional information:**
The idea to feed-back a function inside the emitter is based on this approach:
https://stackoverflow.com/questions/55316490/vue-best-practice-for-calling-a-method-in-a-child-component/70723343#70723343